### PR TITLE
Fixed deprecation warning on precision and precision=

### DIFF
--- a/lib/acts_as_geocodable/geocode.rb
+++ b/lib/acts_as_geocodable/geocode.rb
@@ -38,11 +38,11 @@ class Geocode < ActiveRecord::Base
   end
 
   def precision
-    Graticule::Precision.new(self[:precision])
+    Graticule::Precision.new(read_attribute(:precision))
   end
 
   def precision=(name)
-    self[:precision] = name.to_s
+    write_attribute(:precision, name.to_s)
   end
 
   def geocoded

--- a/spec/geocode_spec.rb
+++ b/spec/geocode_spec.rb
@@ -84,5 +84,13 @@ describe Geocode do
       Geocode.new(:latitude => 1).should_not be_geocoded
     end
   end
+
+  describe "precision" do
+    it "should cast its precision to a Graticule::Precision" do
+      geocode = Geocode.new(:precision => :street)
+      geocode.precision.should be_a Graticule::Precision
+      geocode.precision.to_s.should eql "street"
+    end
+  end
   
 end


### PR DESCRIPTION
self[:attr] and self[:attr]= are deprecated and were giving annoying warnings in Rails 3.2.8

Added relevant test for the method.
