### PR TITLE
Bump Graticule version constraint

### DIFF
--- a/acts_as_geocodable.gemspec
+++ b/acts_as_geocodable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files      = `git ls-files -z`.split("\x0")
   spec.test_files = spec.files.grep(/^spec/)
 
-  spec.add_dependency "graticule", "~> 2.4.0"
+  spec.add_dependency "graticule", [">= 2.4.0", "<= 2.5.0"]
   spec.add_dependency "rails", ">= 3", "< 5.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
#36 

Bumps Graticule version constraint to >2.4 <= 2.5 since 2.4 doesn't raise custom Graticule errors, making it harder to debug issues.

https://github.com/collectiveidea/graticule/commit/5a2b6041889e2e9ffbcdeb62b6e108909be6d78e