### PR TITLE
Loosen graticule requirement to allow all 2.x versions

### DIFF
--- a/acts_as_geocodable.gemspec
+++ b/acts_as_geocodable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files      = `git ls-files -z`.split("\x0")
   spec.test_files = spec.files.grep(/^spec/)
 
-  spec.add_dependency "graticule", "~> 2.4.0"
+  spec.add_dependency "graticule", "~> 2.4"
   spec.add_dependency "rails", ">= 3", "< 5.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Hi there! Hope you'll consider merging this and cutting a release as it's a lot easier to manage versions in a gemfile than making changes in a private fork.

There was not a stated reason for this change and it narrowly restricts graticule to only 2.4.0 while all 2.x versions seem to work fine. We've been running 2.7 of graticule with acts_as_geocodable 2.1.0 for quite some time and there are no other changes.